### PR TITLE
Avoid escaping shell args

### DIFF
--- a/lib/opal/minitest/rake_task.rb
+++ b/lib/opal/minitest/rake_task.rb
@@ -26,7 +26,7 @@ module Opal
               AccessLog: [])
           }
 
-          system "phantomjs \"#{RUNNER_PATH}\" \"http://localhost:#{args[:port]}\""
+          system "phantomjs",  RUNNER_PATH, "http://localhost:#{args[:port]}"
 
           Process.kill(:SIGINT, server)
           Process.wait


### PR DESCRIPTION
Avoid escaping shell args by passing the separately to Kernel#system.
