### PR TITLE
Fix file-extension regexp in require statement in loader.

### DIFF
--- a/opal/opal/minitest/loader.rb.erb
+++ b/opal/opal/minitest/loader.rb.erb
@@ -2,7 +2,7 @@ require 'opal'
 require 'minitest'
 
 <% Dir[$omt_requires_glob].each do |file| %>
-require <%= file.sub(/^test\//, '').sub(/\.{rb,opal}$/, '').inspect %>
+require <%= file.sub(/^test\//, '').sub(/\.(rb|opal)$/, '').inspect %>
 <% end %>
 
 Minitest.run

--- a/vendor/runner.js
+++ b/vendor/runner.js
@@ -5,7 +5,7 @@ var system = require('system');
 var url = system.args[1],
     page = require('webpage').create();
 
-page.onConsoleMessage = function(msg) { console.log(msg) };
+page.onConsoleMessage = function(msg) { system.stdout.write(msg) };
 
 page.open(url, function(loadStatus) {
   if (loadStatus !== 'success') {


### PR DESCRIPTION
I prefer to name my test files `foo_test.js.rb` to keep them separate from server-side tests named `foo_test.rb` (this seems to be the convention of opal-rails as well). This buggy regexp (it was using shell glob-style union rather than regexp union) was preventing opal 0.8.1 from being able to require my test files, because opal only removes one extension. With the fix, opal-minitest now removes `.rb`, and opal removes `.js`. It might be better for opal-minitest to remove both extensions, but I'll leave that design decision up to you...
