### PR TITLE
Avoid extra newlines by using phantomjs stdout.write instead of console.log.

### DIFF
--- a/vendor/runner.js
+++ b/vendor/runner.js
@@ -5,7 +5,7 @@ var system = require('system');
 var url = system.args[1],
     page = require('webpage').create();
 
-page.onConsoleMessage = function(msg) { console.log(msg) };
+page.onConsoleMessage = function(msg) { system.stdout.write(msg) };
 
 page.open(url, function(loadStatus) {
   if (loadStatus !== 'success') {


### PR DESCRIPTION
Inspired by https://github.com/opal/opal/blob/master/lib/opal/cli_runners/phantom.js#L5

Ideally we should probably start using Opal::CLI instead of Opal::Server (in rake_task.rb) but that's a bigger overhaul than I want to tackle right now... This is a quick fix to make the progress dots show up on the same line, yay!
