### PR TITLE
Use the phantomjs gem rather than relying on a system installation.

### DIFF
--- a/lib/opal/minitest/rake_task.rb
+++ b/lib/opal/minitest/rake_task.rb
@@ -1,4 +1,5 @@
 require 'rake'
+require 'phantomjs'
 require 'opal/minitest'
 
 module Opal
@@ -26,11 +27,7 @@ module Opal
               AccessLog: [])
           }
 
-          unless system "phantomjs -v"
-            raise "phantomjs command not found"
-          end
-
-          system "phantomjs", RUNNER_PATH, "http://localhost:#{args[:port]}"
+          system Phantomjs.path, RUNNER_PATH, "http://localhost:#{args[:port]}"
 
           Process.kill(:SIGINT, server)
           Process.wait

--- a/opal-minitest.gemspec
+++ b/opal-minitest.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'opal', '>= 0.8'
   s.add_dependency 'rake', '~> 10'
+  s.add_dependency 'phantomjs'
   s.add_development_dependency 'minitest', '5.3.4'
 end
 


### PR DESCRIPTION
@aostrega: what do you think of this change? I just spent a week tracking down a bug that turned out to be due to my Ubuntu 14.04 installation of PhantomJS being 1.9 instead of 2.1.1... The phantomjs gem will automatically install the latest version of PhantomJS if needed.
