### PR TITLE
Make Assertion an Exception subclass, which now works in Opal 0.9.

### DIFF
--- a/opal-minitest.gemspec
+++ b/opal-minitest.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.require_paths = ['lib']
 
-  s.add_dependency 'opal', '>= 0.8'
+  s.add_dependency 'opal', '>= 0.9'
   s.add_dependency 'rake', '~> 10'
   s.add_development_dependency 'minitest', '5.3.4'
 end

--- a/opal/minitest/core_classes.rb
+++ b/opal/minitest/core_classes.rb
@@ -407,9 +407,7 @@ module Minitest
   ##
   # Represents run failures.
 
-  # PORT: modified
-  #class Assertion < Exception
-  class Assertion
+  class Assertion < Exception
     def error # :nodoc:
       self
     end


### PR DESCRIPTION
Without this change, `skip` raises an error in Opal 0.9.
