### PR TITLE
Use source maps to make exception backtraces more useful.

### DIFF
--- a/lib/opal/minitest/rake_task.rb
+++ b/lib/opal/minitest/rake_task.rb
@@ -51,9 +51,6 @@ module Opal
         attr_reader :requires_glob
 
         def initialize(args)
-          gem_path = Pathname.new(__FILE__).join('../../../..')
-          self.index_path = gem_path.join('opal/opal/minitest/runner.html.erb').to_s
-
           super
 
           $omt_requires_glob = args.fetch(:requires_glob)
@@ -61,7 +58,6 @@ module Opal
           $LOAD_PATH.each { |p| append_path(p) }
           append_path 'test'
           self.main = 'opal/minitest/loader'
-          self.debug = false
         end
       end
     end

--- a/opal-minitest.gemspec
+++ b/opal-minitest.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.require_paths = ['lib']
 
-  s.add_dependency 'opal', '>= 0.8'
+  s.add_dependency 'opal', '>= 0.9'
   s.add_dependency 'rake', '~> 10'
   s.add_development_dependency 'minitest', '5.3.4'
 end

--- a/opal/minitest.rb
+++ b/opal/minitest.rb
@@ -138,9 +138,7 @@ module Minitest
     #self.parallel_executor.shutdown
     reporter.report
 
-    # PORT: modified
-    #reporter.passed?
-    `window.OPAL_TEST_EXIT_STATUS = #{reporter.passed?}`
+    reporter.passed?
   end
 
   ##

--- a/opal/minitest/core_classes.rb
+++ b/opal/minitest/core_classes.rb
@@ -407,9 +407,7 @@ module Minitest
   ##
   # Represents run failures.
 
-  # PORT: modified
-  #class Assertion < Exception
-  class Assertion
+  class Assertion < Exception
     def error # :nodoc:
       self
     end

--- a/opal/minitest/core_classes.rb
+++ b/opal/minitest/core_classes.rb
@@ -433,25 +433,9 @@ module Minitest
     end
 
     # PORT: added
-    def initialize(message = '')
-      @message = message
-    end
-
-    # PORT: added
-    attr_reader :message
-
-    # PORT: added
     def backtrace
-      []
+      Minitest::filter_backtrace(super)
     end
-
-    # PORT: added
-    def inspect
-      "#<#{self.class.name}: '#@message'>"
-    end
-
-    # PORT: added
-    alias to_s message
   end
 
   ##

--- a/opal/opal/minitest/loader.rb.erb
+++ b/opal/opal/minitest/loader.rb.erb
@@ -1,8 +1,12 @@
 require 'opal'
 require 'minitest'
+require 'opal/minitest/source_map_backtrace_filter'
 
 <% Dir[$omt_requires_glob].each do |file| %>
 require <%= file.sub(/^test\//, '').sub(/\.(rb|opal)$/, '').inspect %>
 <% end %>
 
-Minitest.run
+def run_minitest(sourcemap)
+  Minitest.backtrace_filter = Opal::Minitest::SourceMapBacktraceFilter.new(sourcemap)
+  Minitest.run
+end

--- a/opal/opal/minitest/source_map_backtrace_filter.rb
+++ b/opal/opal/minitest/source_map_backtrace_filter.rb
@@ -8,11 +8,16 @@ module Opal
         @sourcemap = sourcemap
       end
 
-      def map_frame(source, line, column)
+      def mapping(source, line, column)
         map = @sourcemap[source]
         if map
-          map = SourceMap::Map.from_json(map)
-          mapping = map.bsearch(SourceMap::Offset.new(line.to_i, column.to_i))
+          SourceMap::Map.from_json(map).bsearch(SourceMap::Offset.new(line.to_i, column.to_i))
+        end
+      end
+
+      def map_frame(source, line, column)
+        mapping = mapping(source, line, column)
+        if mapping
           source = mapping.source.sub(%r{^/__OPAL_SOURCE_MAPS__/|/}, '')
           line = mapping.original.line
           column = mapping.original.column

--- a/opal/opal/minitest/source_map_backtrace_filter.rb
+++ b/opal/opal/minitest/source_map_backtrace_filter.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 require 'minitest'
 require 'source_map'
 
@@ -15,7 +16,7 @@ module Opal
         end
       end
 
-      def map_frame(source, line, column)
+      def map_frame(method, source, line, column)
         mapping = mapping(source, line, column)
         if mapping
           source = mapping.source.sub(%r{^/__OPAL_SOURCE_MAPS__/|/}, '')
@@ -25,13 +26,16 @@ module Opal
           source =~ %r{^http://localhost:\d+/assets/(.*)\.self([^\?]*)}
           source = "#{$1}#{$2}"
         end
-        "#{source}:#{line}:#{column}"
+        frame = "#{source}:#{line}:#{column}"
+        #                                   This is a special utf8 char ---v
+        frame += ":in `#{method[1..-1]}'" if method && method.start_with?('ː')
+        frame
       end
 
       def filter bt
         super.map do |frame|
-          frame =~ /^(?:.*@)?(.*):(\d+):(\d+)$/
-          map_frame($1, $2, $3)
+          frame =~ /^(?:(.*)@)?(.*):(\d+):(\d+)$/
+          map_frame($1, $2, $3, $4)
         end
       end
     end

--- a/opal/opal/minitest/source_map_backtrace_filter.rb
+++ b/opal/opal/minitest/source_map_backtrace_filter.rb
@@ -1,0 +1,34 @@
+require 'minitest'
+require 'source_map'
+
+module Opal
+  module Minitest
+    class SourceMapBacktraceFilter < ::Minitest::BacktraceFilter
+      def initialize(sourcemap)
+        @sourcemap = sourcemap
+      end
+
+      def map_frame(source, line, column)
+        map = @sourcemap[source]
+        if map
+          map = SourceMap::Map.from_json(map)
+          mapping = map.bsearch(SourceMap::Offset.new(line.to_i, column.to_i))
+          source = mapping.source.sub(%r{^/__OPAL_SOURCE_MAPS__/|/}, '')
+          line = mapping.original.line
+          column = mapping.original.column
+        else
+          source =~ %r{^http://localhost:\d+/assets/(.*)\.self([^\?]*)}
+          source = "#{$1}#{$2}"
+        end
+        "#{source}:#{line}:#{column}"
+      end
+
+      def filter bt
+        super.map do |frame|
+          frame =~ /^(?:.*@)?(.*):(\d+):(\d+)$/
+          map_frame($1, $2, $3)
+        end
+      end
+    end
+  end
+end

--- a/opal/opal/minitest/source_map_backtrace_filter.rb
+++ b/opal/opal/minitest/source_map_backtrace_filter.rb
@@ -6,13 +6,13 @@ module Opal
   module Minitest
     class SourceMapBacktraceFilter < ::Minitest::BacktraceFilter
       def initialize(sourcemap)
-        @sourcemap = sourcemap
+        @sourcemap = sourcemap.map { |source, map| [source, SourceMap::Map.from_json(map)] }.to_h
       end
 
       def mapping(source, line, column)
         map = @sourcemap[source]
         if map
-          SourceMap::Map.from_json(map).bsearch(SourceMap::Offset.new(line.to_i, column.to_i))
+          map.bsearch(SourceMap::Offset.new(line.to_i, column.to_i))
         end
       end
 

--- a/vendor/runner.js
+++ b/vendor/runner.js
@@ -1,25 +1,56 @@
-// Headlessly open test loader and wait until tests finish.
+// Headlessly open test loader and run the tests.
 
 var system = require('system');
+var webpage = require('webpage');
 
-var url = system.args[1],
-    page = require('webpage').create();
+var url = system.args[1];
+var page = webpage.create();
+var sourcemap = {};
 
 page.onConsoleMessage = function(msg) { system.stdout.write(msg) };
+
+page.onResourceReceived = function (response) {
+  if (response.stage === "end") {
+    response.headers.forEach(function (header) {
+      if (header.name === "X-Sourcemap") {
+        var original = page.evaluate(function (url, path) {
+          var a = document.createElement('a');
+          a.href = url;
+          a.pathname = path;
+          a.search = '';
+          return a.href;
+        }, response.url, header.value);
+        sourcemap[response.url] = original;
+      }
+    });
+  }
+};
+
+var loadSourcemap = function (i, done) {
+  var sources = Object.keys(sourcemap);
+  if (i < sources.length) {
+    var source = sources[i];
+    var url = sourcemap[source];
+    var page = webpage.create();
+    page.open(url, function (loadStatus) {
+      sourcemap[source] = page.plainText;
+      page.close();
+      loadSourcemap(i+1, done);
+    });
+  } else {
+    done();
+  }
+};
 
 page.open(url, function(loadStatus) {
   if (loadStatus !== 'success') {
     console.error("Cannot load: " + url);
     phantom.exit(1);
   }
-  var loop = setInterval(function() {
-    var exitStatus = page.evaluate(function() {
-      return window.OPAL_TEST_EXIT_STATUS;
-    });
-
-    if (exitStatus != null) {
-      clearInterval(loop);
-      phantom.exit(exitStatus);
-    }
-  }, 500);
+  loadSourcemap(0, function () {
+    var exitStatus = page.evaluate(function (sourcemap) {
+      return Opal.Object.$run_minitest(Opal.hash(sourcemap));
+    }, sourcemap);
+    phantom.exit(exitStatus);
+  });
 });


### PR DESCRIPTION
(This pull request includes the commit from #10, so you may want to merge that first.)

I got tired of seeing useless backtraces from tests that raise exceptions, so I decided to use the sourcemaps provided by `Opal::Server` to filter backtraces, translating locations in generated Javascript to source locations in the original Ruby where possible. It's a little hacky so please feel free to suggest improvements!
