### PR TITLE
Set a default encoding so that mu_pp doesn't raise an error.

### DIFF
--- a/opal/opal/minitest/loader.rb.erb
+++ b/opal/opal/minitest/loader.rb.erb
@@ -1,6 +1,8 @@
 require 'opal'
 require 'minitest'
 
+Encoding.default_external ||= 'UTF-8'
+
 <% Dir[$omt_requires_glob].each do |file| %>
 require <%= file.sub(/^test\//, '').sub(/\.(rb|opal)$/, '').inspect %>
 <% end %>


### PR DESCRIPTION
When `Encoding.default_external` is `nil` (which it is in Opal by default), `mu_pp` raises an error, e.g. when pretty-printing a value in a failed assertion message. I don't know why Opal doesn't set this by default (e.g. from the document encoding); might be a bug. We can remove this line if that changes.
