### PR TITLE
Put the expected string on the left side of assert_match.

### DIFF
--- a/test/example_test.rb
+++ b/test/example_test.rb
@@ -17,7 +17,7 @@ class ExampleTest < Minitest::Test
       warn 'boo'
     end
 
-    assert_match out, 'woo'
-    assert_match err, 'boo'
+    assert_match 'woo', out
+    assert_match 'boo', err
   end
 end


### PR DESCRIPTION
When combined with #10, this makes `rake` pass all the tests, except for the one intentional failing test.
